### PR TITLE
feat: add nestjs backend server with core endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "backend",
+  "version": "0.0.1",
+  "description": "Work hours management backend",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
+import { HoursModule } from './hours/hours.module';
+import { RequestsModule } from './requests/requests.module';
+
+@Module({
+  imports: [AuthModule, HoursModule, RequestsModule],
+})
+export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+class LoginDto {
+  fullName: string;
+  civilNumber: string;
+}
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('login')
+  login(@Body() dto: LoginDto) {
+    return this.authService.login(dto.fullName, dto.civilNumber);
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthService {
+  async login(fullName: string, civilNumber: string) {
+    if (!fullName || !civilNumber) {
+      throw new Error('Invalid credentials');
+    }
+    return {
+      token: 'demo-token',
+      user: {
+        id: 'u-' + civilNumber,
+        name: fullName.trim(),
+        civilNumber,
+      },
+    };
+  }
+}

--- a/backend/src/hours/hours.controller.ts
+++ b/backend/src/hours/hours.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { HoursService } from './hours.service';
+
+@Controller('hours')
+export class HoursController {
+  constructor(private readonly hoursService: HoursService) {}
+
+  @Get('daily')
+  daily(@Query('month') month: string) {
+    return this.hoursService.daily(month);
+  }
+
+  @Get('summary')
+  summary(@Query('month') month: string) {
+    return this.hoursService.summary(month);
+  }
+}

--- a/backend/src/hours/hours.module.ts
+++ b/backend/src/hours/hours.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HoursService } from './hours.service';
+import { HoursController } from './hours.controller';
+
+@Module({
+  providers: [HoursService],
+  controllers: [HoursController],
+})
+export class HoursModule {}

--- a/backend/src/hours/hours.service.ts
+++ b/backend/src/hours/hours.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+
+export type WorkDay = {
+  id: string;
+  date: string;
+  start: string;
+  end: string;
+  breakMinutes: number;
+  note?: string;
+  approved?: boolean;
+};
+
+export type MonthSummary = {
+  month: string;
+  totalHours: number;
+  overtimeHours: number;
+};
+
+@Injectable()
+export class HoursService {
+  async daily(month: string): Promise<WorkDay[]> {
+    const [year, m] = month.split('-').map(Number);
+    const result: WorkDay[] = [];
+    const date = new Date(year, m - 1, 1);
+    let idx = 0;
+    while (date.getMonth() === m - 1) {
+      const day = date.getDate();
+      const ds = date.toISOString().slice(0, 10);
+      result.push({
+        id: String(idx++),
+        date: ds,
+        start: '09:00',
+        end: date.getDay() === 0 || date.getDay() === 6 ? '00:00' : '18:00',
+        breakMinutes: 60,
+        note: day % 5 === 0 ? 'Meeting day' : undefined,
+      });
+      date.setDate(day + 1);
+    }
+    return result;
+  }
+
+  async summary(month: string): Promise<MonthSummary> {
+    const days = await this.daily(month);
+    const totalHours = days.reduce((acc, d) => acc + (d.end === '00:00' ? 0 : 8), 0);
+    return {
+      month,
+      totalHours,
+      overtimeHours: Math.max(0, totalHours - 160),
+    };
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { RequestsService, RequestType } from './requests.service';
+
+class CreateRequestDto {
+  type: RequestType;
+  startDate: string;
+  endDate: string;
+}
+
+@Controller('requests')
+export class RequestsController {
+  constructor(private readonly requestsService: RequestsService) {}
+
+  @Get()
+  list() {
+    return this.requestsService.list();
+  }
+
+  @Post()
+  create(@Body() dto: CreateRequestDto) {
+    return this.requestsService.create(dto);
+  }
+
+  @Patch(':id/cancel')
+  cancel(@Param('id') id: string) {
+    return this.requestsService.cancel(id);
+  }
+}

--- a/backend/src/requests/requests.module.ts
+++ b/backend/src/requests/requests.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RequestsService } from './requests.service';
+import { RequestsController } from './requests.controller';
+
+@Module({
+  providers: [RequestsService],
+  controllers: [RequestsController],
+})
+export class RequestsModule {}

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+
+export type RequestStatus = 'ожидает' | 'одобрено' | 'отклонено';
+export type RequestType = 'Отпуск' | 'Больничный' | 'Сверхурочная' | 'Компенсация';
+
+export interface RequestItem {
+  id: string;
+  type: RequestType;
+  startDate: string;
+  endDate: string;
+  days: number;
+  status: RequestStatus;
+}
+
+@Injectable()
+export class RequestsService {
+  private items: RequestItem[] = [];
+
+  list() {
+    return this.items;
+  }
+
+  create(it: { type: RequestType; startDate: string; endDate: string; }) {
+    const days = this.daysBetween(it.startDate, it.endDate);
+    const newItem: RequestItem = {
+      id: Math.random().toString(36).slice(2, 9),
+      type: it.type,
+      startDate: it.startDate,
+      endDate: it.endDate,
+      days,
+      status: 'ожидает',
+    };
+    this.items.unshift(newItem);
+    return newItem;
+  }
+
+  cancel(id: string) {
+    const idx = this.items.findIndex(i => i.id === id);
+    if (idx >= 0) {
+      this.items[idx].status = 'отклонено';
+      return this.items[idx];
+    }
+    return undefined;
+  }
+
+  private daysBetween(a: string, b: string) {
+    const start = new Date(a);
+    const end = new Date(b);
+    const diff = Math.ceil((end.getTime() - start.getTime()) / 86400000);
+    return diff >= 0 ? diff + 1 : 1;
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold new NestJS backend
- add auth login endpoint
- implement hours and requests APIs

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `npm run build` *(fails: cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_68b470870f50832e867c4b4785fd6bde